### PR TITLE
chore(lint): lint ts and tsx files

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-dom": "^17.0.2"
   },
   "lint-staged": {
-    "*.{js,css,md}": "prettier --write"
+    "*.{js,jsx,css,md,ts,tsx}": "prettier --write"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
# What?

This PR gets lint-staged to run for .jsx, .ts and .tsx files.

# Why?

Linting issues were cropping up in #1 for those files, presumably due to lint-staged not running when it should've