### PR TITLE
docs(readme): add shields to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This is a collection of shared front-end components for multi-user-domain projects.
 
+![npm bundle size](https://img.shields.io/bundlephobia/min/@multi-user-domain/mud-lib)
+![npm (scoped)](https://img.shields.io/npm/v/@multi-user-domain/mud-lib)
+
 ## Tech used
 
 - React


### PR DESCRIPTION
# What?

Adds shields to README showing bundle size and version.

# Why?

Makes us look more legit (I swear big repos seem to have loads of these)