### PR TITLE
docs(template): add initial pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+# What does this PR do?
+
+_describe what new functionality or changes this PR makes, at a high level_
+
+# Why should we merge this?
+
+_justify why the changes are required, or give background around the problem it's trying to solve_


### PR DESCRIPTION
# What does this PR do?

Introduces a standardised PR template to the project. Note: I'm not sure on the actual format, totally open to suggestions - this initial commit (https://github.com/Multi-User-Domain/mud-lib/pull/5/commits/625fcc635e2b1794f76e9000677a3d00f5b74ee5) was just to give something to work off.

# Why should we merge this?

To help keep PRs structured, and provide prompts for the sort of information we ought to be including in PRs.